### PR TITLE
added status display

### DIFF
--- a/src/App.java
+++ b/src/App.java
@@ -94,7 +94,7 @@ public class App {
 	}
 
 	public void updateGitStatus() {
-		// implement behavior
+		statusText.setText(gitSubprocessClient.gitStatus());
 	}
 
 }

--- a/src/App.java
+++ b/src/App.java
@@ -10,6 +10,8 @@ public class App {
 	private String repoPath;
 	private GitSubprocessClient gitSubprocessClient;
 
+	private JTextField statusField;
+
 	public App() {
 		JFrame mainWindow = new JFrame("Git Helper");
 
@@ -39,6 +41,43 @@ public class App {
 
 		mainPanel.add(repoSelectPanel, BorderLayout.NORTH);
 		// end repo selection panel setup
+
+		// setting up center panel
+		JPanel centerPanel = new JPanel(new GridLayout(1, 3));
+
+		// setting up status panel of center
+		JPanel statusPanel = new JPanel(new GridLayout(2, 1));
+
+		JButton refreshButton = new JButton("Refresh Status");
+		statusField = new JTextField(30);
+		statusField.setEditable(false);
+		updateGitStatus();
+
+		// adding listener to update status text box
+		refreshButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				updateGitStatus();
+			}
+		});
+
+		statusPanel.add(refreshButton);
+		statusPanel.add(statusField);
+
+		centerPanel.add(statusPanel);
+		// end status panel setup
+
+		// placeholder panels for center panel
+		JPanel panel1 = new JPanel();
+		panel1.setBackground(Color.blue);
+		JPanel panel2 = new JPanel();
+		panel2.setBackground(Color.red);
+
+		centerPanel.add(panel1);
+		centerPanel.add(panel2);
+
+		mainPanel.add(centerPanel, BorderLayout.CENTER);
+		// end center panel setup
 
 		mainWindow.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		mainWindow.setSize(1000, 1000);

--- a/src/App.java
+++ b/src/App.java
@@ -46,12 +46,16 @@ public class App {
 		JPanel centerPanel = new JPanel(new GridLayout(1, 3));
 
 		// setting up status panel of center
-		JPanel statusPanel = new JPanel(new GridLayout(2, 1));
+		JPanel statusPanel = new JPanel(new BorderLayout());
 
+		JPanel refreshPanel = new JPanel();
 		JButton refreshButton = new JButton("Refresh Status");
+		refreshPanel.add(refreshButton);
+
+		JPanel statusTextPanel = new JPanel();
 		statusField = new JTextField(30);
 		statusField.setEditable(false);
-		updateGitStatus();
+		statusTextPanel.add(statusField);
 
 		// adding listener to update status text box
 		refreshButton.addActionListener(new ActionListener() {
@@ -61,8 +65,8 @@ public class App {
 			}
 		});
 
-		statusPanel.add(refreshButton);
-		statusPanel.add(statusField);
+		statusPanel.add(refreshPanel, BorderLayout.NORTH);
+		statusPanel.add(statusTextPanel, BorderLayout.CENTER);
 
 		centerPanel.add(statusPanel);
 		// end status panel setup

--- a/src/App.java
+++ b/src/App.java
@@ -10,7 +10,7 @@ public class App {
 	private String repoPath;
 	private GitSubprocessClient gitSubprocessClient;
 
-	private JTextField statusField;
+	private JTextArea statusText;
 
 	public App() {
 		JFrame mainWindow = new JFrame("Git Helper");
@@ -53,9 +53,9 @@ public class App {
 		refreshPanel.add(refreshButton);
 
 		JPanel statusTextPanel = new JPanel();
-		statusField = new JTextField(30);
-		statusField.setEditable(false);
-		statusTextPanel.add(statusField);
+		statusText = new JTextArea(20, 30);
+		statusText.setEditable(false);
+		statusTextPanel.add(statusText);
 
 		// adding listener to update status text box
 		refreshButton.addActionListener(new ActionListener() {

--- a/src/App.java
+++ b/src/App.java
@@ -12,6 +12,7 @@ public class App {
 
 	private JTextArea statusText;
 	private JLabel loadFailLabel;
+	private JScrollPane statusPane;
 
 	public App() {
 		JFrame mainWindow = new JFrame("Git Helper");
@@ -69,8 +70,8 @@ public class App {
 		statusText = new JTextArea(20, 25);
 		statusText.setEditable(false);
 		statusText.setMargin(new Insets(10, 10, 10, 10));
-		statusText.setLineWrap(true);
-		statusTextPanel.add(statusText);
+		statusPane = new JScrollPane(statusText);
+		statusTextPanel.add(statusPane);
 
 		// adding listener to update status text box
 		refreshButton.addActionListener(new ActionListener() {
@@ -119,6 +120,8 @@ public class App {
 				showLoadFail();
 			}
 		}
+
+		statusText.setText(statusText.getText() + "\n"); // moves the status pane to show the left of the panel, not right
 	}
 
 	public void showLoadFail() {


### PR DESCRIPTION
Added a scrolling text window that displays the status of the currently selected local repository. It also displays an error if the GitSubprocessClient was not loaded properly or the directory is not a repository. I also added some temporary panels that are blue and red to fill in the GridLayout in the center. These temporary panels will be removed and replaced once the control panels are finished.